### PR TITLE
this is why should be better to remove the async and defer part of script tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,9 +55,9 @@
     <!-- Load Scripts last -->
     <script src="js/jquery.min.js"></script>
     <script type="text/javascript" src="js/map.js"></script>
-    <script src="https://maps.googleapis.com/maps/api/js?libraries=places&callback=appMap.init" async defer></script>
     <script type="text/javascript" src="http://knockoutjs.com/downloads/knockout-3.3.0.js"></script>
     <script type="text/javascript" src="js/app.js"></script>
+    <script src="http://maps.googleapis.com/maps/api/js?libraries=places&callback=appMap.init" async defer onload="appMap.load(event)" onerror="appMap.load(event)"></script>
 
 
 </body>

--- a/js/app.js
+++ b/js/app.js
@@ -29,14 +29,17 @@
             Notice.notice(msg, 'error');
         }
     };
+
     // error catching
     try {
-        google.maps;
         ko.observable();
 
-        app();
+        appMap.onLoad(app, function error() {
+            Notice.error("There was problem loading the Google Map, please check your internet.");
+        })
+        // app();
     } catch (e) {
-        Notice.error("There was problem loading the Google Map, please check your internet.");
+        Notice.error("There was problem loading an external library, please check your internet.");
         // fade out side bar and search bar if error
         $('.sidebar, .searchbar').fadeOut(200);
     }
@@ -218,7 +221,7 @@
 
         // Controller
         var LocationController = function LocationController() {
-            console.log("Controller Loction started...");
+            console.log("Controller Location started...");
 
             appMap.getPlaces(function(results, status) {
                 PlaceModel.import(results);

--- a/js/map.js
+++ b/js/map.js
@@ -10,6 +10,26 @@
         lng: -43.204444
     };
 
+    var onLoad = function() {};
+    var onError = function() {};
+
+    appMap.onLoad = function( success, error ) {
+        onLoad = success;
+        onError = error;
+
+        return appMap;
+    };
+
+    appMap.load = function(ev) {
+        // we pass the event ev, so we can check if the event is an ErrorEvent
+        // we check if the map was succesfully loaded (just check the appMap.map)
+        if (appMap.map) {
+            onLoad.call(appMap);
+        } else {
+            onError.call(appMap, ev);
+        }
+    };
+
     /*
         Utility For Initializing The Google Map
         Needs To Be Global
@@ -19,7 +39,7 @@
 
         /*
             Instantiate a new map object
-    */
+        */
         appMap.map = new google.maps.Map(mapDiv, {
             center: startPoint,
             zoom: 15


### PR DESCRIPTION
because the script loading the google maps is asynchronous, add the onload and onerror event listener, and make the app load just when the script was correctly loaded, because the app depends on Google map.

We are using a module pattern, so things should be separated as different modules when making the correct dependencies between them. Using that kind of functionality may need a dependency handler/loader for getting the real benefit.
